### PR TITLE
Add mcfly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -268,6 +268,7 @@ I curate a list of [interesting CLI tools](https://github.com/learn-anything/com
 - [wifi-password](https://github.com/rauchg/wifi-password) - Get the password of the WiFi you're on.
 - [fkill](https://github.com/sindresorhus/fkill-cli) - Fabulously kill processes.
 - [ran](https://github.com/m3ng9i/ran) - Simple static web server written in Go.
+- [mcfly](https://github.com/cantino/mcfly) - Fast visual command history search.
 
 ## Launchpad
 


### PR DESCRIPTION
Adds cantino's `mcfly`, which is a Rust utility that provides fast visual search through your shell's command history.